### PR TITLE
cvdl-ts: package cvdl as a command line utility

### DIFF
--- a/cvdl-ts/package.json
+++ b/cvdl-ts/package.json
@@ -1,27 +1,30 @@
 {
-	"name": "cvdl-ts",
-	"version": "1.0.24",
-	"description": "Typescript Implementation of CVDL Compiler",
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": ["/dist"],
-	"dependencies": {
-		"@types/blob-stream": "^0.1.32",
-		"@types/fontkit": "^2.0.5",
-		"@types/pdfkit": "^0.13.1",
-		"blob-stream": "^0.1.3",
-		"fontkit": "^2.0.2",
-		"marked": "^13.0.2",
-		"pdfkit": "^0.13.0",
-		"ts-pattern": "^5.2.0"
-	},
-	"devDependencies": {
-		"@types/node": "^20.8.7",
-		"globals": "^15.8.0"
-	},
-	"scripts": {
-		"build": "tsc",
-		"start": "ts-node src/index.ts",
-		"cli": "ts-node src/cli.ts"
-	}
+  "name": "cvdl-ts",
+  "version": "1.0.24",
+  "description": "Typescript Implementation of CVDL Compiler",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist"
+  ],
+  "dependencies": {
+    "@types/blob-stream": "^0.1.32",
+    "@types/fontkit": "^2.0.5",
+    "@types/pdfkit": "^0.13.1",
+    "blob-stream": "^0.1.3",
+    "fontkit": "^2.0.2",
+    "marked": "^13.0.2",
+    "pdfkit": "^0.13.0",
+    "ts-pattern": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.7",
+    "globals": "^15.8.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "ts-node src/index.ts",
+    "start:cli": "node src/cli/index.js",
+    "cli": "ts-node src/cli.ts"
+  }
 }

--- a/cvdl-ts/src/cli/index.js
+++ b/cvdl-ts/src/cli/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+//** This executable file will have the commands for the CLI */

--- a/cvdl-ts/src/cli/package.json
+++ b/cvdl-ts/src/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cvdl-ts",
+  "version": "1.0.0",
+  "description": "A CLI tool for cvdl-ts",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "cvdl-ts": "./index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node index.js"
+  },
+  "keywords": [
+    "cvdl-ts"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alpaylan/tail"
+  },
+  "bugs": {
+    "url": "https://github.com/alpaylan/tail/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/alpaylan/tail"
+}


### PR DESCRIPTION
- Created a package.json file inside the CLI module

- Added  a script for running CLI via `npm run start:cli` 

Currently, the CLI module is a part of cvdl-ts, and I will add more features later on. The module is also ready to be published via `npm publish --access=public`